### PR TITLE
Add simple modular PHP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # devzign_institute
-Educational Perpose
+
+This repository demonstrates a very small PHP backend built in a modular way for educational purposes.
+
+## Project structure
+
+```
+public/          # Document root used by the PHP development server
+    index.php    # Entry file that registers routes
+src/
+    Router.php   # Minimal HTTP router
+    controllers/
+        HelloController.php  # Sample controller
+```
+
+## Prerequisites
+- PHP 8 or later installed on your system.
+
+## Running the application
+
+1. Navigate to this directory in your terminal.
+2. Start the built-in PHP development server:
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+3. Open your browser and visit [http://localhost:8000](http://localhost:8000).
+   You should see `Hello from the PHP backend!` displayed.
+
+## Extending the code
+- Add new routes in `public/index.php` using `$router->get('/path', [ClassName::class, 'method']);`.
+- Create additional controllers inside `src/controllers` to organize your logic.
+
+This setup keeps the code modular and easy to expand for larger projects.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/../src/Router.php';
+require_once __DIR__ . '/../src/controllers/HelloController.php';
+
+$router = new Router();
+$router->get('/', [HelloController::class, 'index']);
+$router->run();

--- a/src/Router.php
+++ b/src/Router.php
@@ -1,0 +1,20 @@
+<?php
+class Router {
+    private $getRoutes = [];
+
+    public function get($path, $callable) {
+        $this->getRoutes[$path] = $callable;
+    }
+
+    public function run() {
+        $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+        $method = $_SERVER['REQUEST_METHOD'];
+
+        if ($method === 'GET' && isset($this->getRoutes[$uri])) {
+            echo call_user_func($this->getRoutes[$uri]);
+        } else {
+            http_response_code(404);
+            echo "404 Not Found";
+        }
+    }
+}

--- a/src/controllers/HelloController.php
+++ b/src/controllers/HelloController.php
@@ -1,0 +1,6 @@
+<?php
+class HelloController {
+    public static function index() {
+        return "Hello from the PHP backend!";
+    }
+}


### PR DESCRIPTION
## Summary
- create a minimal PHP backend with a router and controller
- provide a sample entry point in `public/index.php`
- update README with setup and usage instructions

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d6115f2083318ecb2eb204057a24