### PR TITLE
Add devzign id to registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# devzign_institute
-Educational Perpose
+# Devzign Institute Backend
+
+Sample PHP backend for an education platform with basic authentication, course management, and Q&A forum. APIs live under `api/` and a very small admin panel is available under `admin/`.
+Each user receives a unique `devzign_id` when registering.
+
+## Setup
+
+1. Create MySQL database and import `database.sql`.
+2. Set environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` or edit `config/config.php`.
+3. Deploy the `api/` and `admin/` directories on a PHP server.
+
+API entry point is `api/index.php` and accepts requests like:
+
+```
+POST /api/index.php?path=auth/register
+POST /api/index.php?path=auth/login
+GET  /api/index.php?path=courses
+```
+The registration endpoint returns a JSON object including a `devzign_id` for the new user.

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+if (!isset($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+    header('Location: login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Admin Dashboard</title>
+</head>
+<body>
+<h1>Welcome, <?php echo htmlspecialchars($_SESSION['user']['name']); ?></h1>
+<ul>
+    <li><a href="users.php">Manage Users</a></li>
+    <li><a href="courses.php">Manage Courses</a></li>
+    <li><a href="logout.php">Logout</a></li>
+</ul>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../config/Database.php';
+require_once __DIR__ . '/../models/User.php';
+
+$config = require __DIR__ . '/../config/config.php';
+$db = new Database($config);
+$userModel = new User($db->getConnection());
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = $userModel->findByEmail($_POST['email']);
+    if ($user && password_verify($_POST['password'], $user['password']) && $user['role'] === 'admin') {
+        $_SESSION['user'] = ['id' => $user['id'], 'role' => 'admin', 'name' => $user['name']];
+        header('Location: index.php');
+        exit;
+    }
+    $error = 'Invalid credentials';
+}
+?>
+<!DOCTYPE html>
+<html>
+<head><title>Admin Login</title></head>
+<body>
+<form method="post">
+    <input type="email" name="email" placeholder="Email" required><br>
+    <input type="password" name="password" placeholder="Password" required><br>
+    <button type="submit">Login</button>
+</form>
+<?php if (isset($error)) echo '<p>' . $error . '</p>'; ?>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+require_once __DIR__ . '/../middleware/AuthMiddleware.php';
+requireRole(['admin']);
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../config/Database.php';
+require_once __DIR__ . '/../models/User.php';
+
+$config = require __DIR__ . '/../config/config.php';
+$db = new Database($config);
+$userModel = new User($db->getConnection());
+$users = $userModel->all();
+?>
+<!DOCTYPE html>
+<html>
+<head><title>Users</title></head>
+<body>
+<h1>Users</h1>
+<table border="1">
+<tr><th>ID</th><th>Email</th><th>Role</th><th>Name</th><th>Devzign ID</th></tr>
+<?php foreach ($users as $u): ?>
+<tr>
+<td><?php echo $u['id']; ?></td>
+<td><?php echo htmlspecialchars($u['email']); ?></td>
+<td><?php echo $u['role']; ?></td>
+<td><?php echo htmlspecialchars($u['name']); ?></td>
+<td><?php echo htmlspecialchars($u['devzign_id']); ?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+</body>
+</html>

--- a/api/index.php
+++ b/api/index.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../routes/api.php';

--- a/config/Database.php
+++ b/config/Database.php
@@ -1,0 +1,20 @@
+<?php
+class Database {
+    private $conn;
+
+    public function __construct($config) {
+        $this->conn = new mysqli(
+            $config['db_host'],
+            $config['db_user'],
+            $config['db_pass'],
+            $config['db_name']
+        );
+        if ($this->conn->connect_error) {
+            die('Database connection error: ' . $this->conn->connect_error);
+        }
+    }
+
+    public function getConnection() {
+        return $this->conn;
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'db_host' => getenv('DB_HOST') ?: 'localhost',
+    'db_name' => getenv('DB_NAME') ?: 'education',
+    'db_user' => getenv('DB_USER') ?: 'root',
+    'db_pass' => getenv('DB_PASS') ?: ''
+];

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -1,0 +1,43 @@
+<?php
+require_once __DIR__ . '/../models/User.php';
+require_once __DIR__ . '/../config/Database.php';
+
+class AuthController {
+    private $user;
+
+    public function __construct($db) {
+        $this->user = new User($db);
+    }
+
+    public function register($data) {
+        if ($this->user->findByEmail($data['email'])) {
+            return ['error' => 'Email already exists'];
+        }
+        $data['role'] = $data['role'] ?? 'student';
+        $data['devzign_id'] = uniqid('DZ');
+        $this->user->create($data);
+        return [
+            'success' => true,
+            'message' => 'Registration successful',
+            'devzign_id' => $data['devzign_id']
+        ];
+    }
+
+    public function login($email, $password) {
+        $record = $this->user->findByEmail($email);
+        if ($record && password_verify($password, $record['password'])) {
+            $_SESSION['user'] = [
+                'id' => $record['id'],
+                'role' => $record['role'],
+                'name' => $record['name']
+            ];
+            return ['success' => true];
+        }
+        return ['error' => 'Invalid credentials'];
+    }
+
+    public function logout() {
+        session_destroy();
+        return ['success' => true];
+    }
+}

--- a/controllers/CourseController.php
+++ b/controllers/CourseController.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../models/Course.php';
+
+class CourseController {
+    private $course;
+
+    public function __construct($db) {
+        $this->course = new Course($db);
+    }
+
+    public function create($data) {
+        return $this->course->create($data);
+    }
+
+    public function list() {
+        return $this->course->all();
+    }
+}

--- a/controllers/QuestionController.php
+++ b/controllers/QuestionController.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../models/Question.php';
+
+class QuestionController {
+    private $question;
+
+    public function __construct($db) {
+        $this->question = new Question($db);
+    }
+
+    public function create($data) {
+        return $this->question->create($data);
+    }
+
+    public function list() {
+        return $this->question->all();
+    }
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,31 @@
+-- Users table
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin','student','tutor','parent') NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    devzign_id VARCHAR(32) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Courses table
+CREATE TABLE courses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    tutor_id INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    price INT DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (tutor_id) REFERENCES users(id)
+);
+
+-- Questions table
+CREATE TABLE questions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/middleware/AuthMiddleware.php
+++ b/middleware/AuthMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+
+function requireRole($roles) {
+    if (!isset($_SESSION['user'])) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Unauthorized']);
+        exit;
+    }
+    if (!in_array($_SESSION['user']['role'], (array)$roles)) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Forbidden']);
+        exit;
+    }
+}

--- a/models/Course.php
+++ b/models/Course.php
@@ -1,0 +1,19 @@
+<?php
+class Course {
+    private $db;
+    private $table = 'courses';
+
+    public function __construct($db) {
+        $this->db = $db;
+    }
+
+    public function create($data) {
+        $stmt = $this->db->prepare("INSERT INTO {$this->table} (title, description, tutor_id, price) VALUES (?, ?, ?, ?)");
+        $stmt->bind_param('ssii', $data['title'], $data['description'], $data['tutor_id'], $data['price']);
+        return $stmt->execute();
+    }
+
+    public function all() {
+        return $this->db->query("SELECT * FROM {$this->table}")->fetch_all(MYSQLI_ASSOC);
+    }
+}

--- a/models/Question.php
+++ b/models/Question.php
@@ -1,0 +1,19 @@
+<?php
+class Question {
+    private $db;
+    private $table = 'questions';
+
+    public function __construct($db) {
+        $this->db = $db;
+    }
+
+    public function create($data) {
+        $stmt = $this->db->prepare("INSERT INTO {$this->table} (user_id, title, body) VALUES (?, ?, ?)");
+        $stmt->bind_param('iss', $data['user_id'], $data['title'], $data['body']);
+        return $stmt->execute();
+    }
+
+    public function all() {
+        return $this->db->query("SELECT * FROM {$this->table}")->fetch_all(MYSQLI_ASSOC);
+    }
+}

--- a/models/User.php
+++ b/models/User.php
@@ -1,0 +1,34 @@
+<?php
+class User {
+    private $db;
+    private $table = 'users';
+
+    public function __construct($db) {
+        $this->db = $db;
+    }
+
+    public function create($data) {
+        $stmt = $this->db->prepare("INSERT INTO {$this->table} (email, password, role, name, devzign_id) VALUES (?, ?, ?, ?, ?)");
+        $password = password_hash($data['password'], PASSWORD_BCRYPT);
+        $stmt->bind_param('sssss', $data['email'], $password, $data['role'], $data['name'], $data['devzign_id']);
+        return $stmt->execute();
+    }
+
+    public function findByEmail($email) {
+        $stmt = $this->db->prepare("SELECT * FROM {$this->table} WHERE email = ? LIMIT 1");
+        $stmt->bind_param('s', $email);
+        $stmt->execute();
+        return $stmt->get_result()->fetch_assoc();
+    }
+
+    public function find($id) {
+        $stmt = $this->db->prepare("SELECT * FROM {$this->table} WHERE id = ?");
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        return $stmt->get_result()->fetch_assoc();
+    }
+
+    public function all() {
+        return $this->db->query("SELECT id, email, role, name, devzign_id FROM {$this->table}")->fetch_all(MYSQLI_ASSOC);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,57 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../config/Database.php';
+require_once __DIR__ . '/../controllers/AuthController.php';
+require_once __DIR__ . '/../controllers/CourseController.php';
+require_once __DIR__ . '/../controllers/QuestionController.php';
+require_once __DIR__ . '/../middleware/AuthMiddleware.php';
+
+$config = require __DIR__ . '/../config/config.php';
+$db = new Database($config);
+
+$authController = new AuthController($db->getConnection());
+$courseController = new CourseController($db->getConnection());
+$questionController = new QuestionController($db->getConnection());
+
+$method = $_SERVER['REQUEST_METHOD'];
+$path = $_GET['path'] ?? '';
+
+header('Content-Type: application/json');
+
+switch ("$method $path") {
+    case 'POST auth/register':
+        $data = json_decode(file_get_contents('php://input'), true);
+        echo json_encode($authController->register($data));
+        break;
+    case 'POST auth/login':
+        $data = json_decode(file_get_contents('php://input'), true);
+        echo json_encode($authController->login($data['email'], $data['password']));
+        break;
+    case 'POST auth/logout':
+        echo json_encode($authController->logout());
+        break;
+
+    case 'POST courses':
+        requireRole(['tutor']);
+        $data = json_decode(file_get_contents('php://input'), true);
+        $data['tutor_id'] = $_SESSION['user']['id'];
+        echo json_encode($courseController->create($data));
+        break;
+    case 'GET courses':
+        echo json_encode($courseController->list());
+        break;
+
+    case 'POST questions':
+        requireRole(['student']);
+        $data = json_decode(file_get_contents('php://input'), true);
+        $data['user_id'] = $_SESSION['user']['id'];
+        echo json_encode($questionController->create($data));
+        break;
+    case 'GET questions':
+        echo json_encode($questionController->list());
+        break;
+
+    default:
+        http_response_code(404);
+        echo json_encode(['error' => 'Not Found']);
+}


### PR DESCRIPTION
## Summary
- generate a unique devzign_id when registering users
- include devzign_id and message in registration response
- store devzign_id in database and list it in admin panel
- document devzign_id in README

## Testing
- `git status --short`
- `php` commands were unavailable, so no syntax validation was executed

------
https://chatgpt.com/codex/tasks/task_e_6865174dc0a483318e8a7dcee94b4742